### PR TITLE
Allow for checking device not reachable

### DIFF
--- a/src/checks/ReachabilityCheck.py
+++ b/src/checks/ReachabilityCheck.py
@@ -14,10 +14,10 @@ class ReachabilityCheck(AbstractCheck):
 
         if destination.startswith("!"):
             destination = destination[1:]
-            self.description = f"Verifying `{destination}` reachable from device `{device_name}`"
+            self.description = f"Verifying `{destination}` not reachable from device `{device_name}`"
             invert = True
         else:
-            self.description = f"Verifying `{destination}` not reachable from device `{device_name}`"
+            self.description = f"Verifying `{destination}` reachable from device `{device_name}`"
             invert = False
 
         try:
@@ -34,9 +34,10 @@ class ReachabilityCheck(AbstractCheck):
         try:
             parsed_output = jc.parse("ping", output)
             if int(parsed_output['packets_received']) > 0:
+                reason = "OK" if invert else f"`{device_name}` can reach `{destination}`."
                 return CheckResult(self.description, invert ^ True, "OK")
             else:
-                reason = f"`{device_name}` does not receive any answer from `{destination}`."
+                reason = "OK" if invert else f"`{device_name}` does not receive any answer from `{destination}`."
                 return CheckResult(self.description, invert ^ False, reason)
         except Exception:
             return CheckResult(self.description, False, output.strip())

--- a/src/checks/ReachabilityCheck.py
+++ b/src/checks/ReachabilityCheck.py
@@ -10,9 +10,15 @@ from .CheckResult import CheckResult
 class ReachabilityCheck(AbstractCheck):
 
     def check(self, device_name: str, destination: str, lab: Lab) -> CheckResult:
-        self.description = f"Verifying `{destination}` reachability from device `{device_name}`"
-
         kathara_manager: Kathara = Kathara.get_instance()
+
+        if destination.startswith("!"):
+            destination = destination[1:]
+            self.description = f"Verifying `{destination}` reachable from device `{device_name}`"
+            invert = True
+        else:
+            self.description = f"Verifying `{destination}` not reachable from device `{device_name}`"
+            invert = False
 
         try:
             exec_output_gen = kathara_manager.exec(
@@ -21,17 +27,17 @@ class ReachabilityCheck(AbstractCheck):
                 lab_hash=lab.hash,
             )
         except Exception as e:
-            return CheckResult(self.description, False, str(e))
+            return CheckResult(self.description, invert ^ False, str(e))
 
         output = get_output(exec_output_gen).replace("ERROR: ", "")
 
         try:
             parsed_output = jc.parse("ping", output)
             if int(parsed_output['packets_received']) > 0:
-                return CheckResult(self.description, True, "OK")
+                return CheckResult(self.description, invert ^ True, "OK")
             else:
                 reason = f"`{device_name}` does not receive any answer from `{destination}`."
-                return CheckResult(self.description, False, reason)
+                return CheckResult(self.description, invert ^ False, reason)
         except Exception:
             return CheckResult(self.description, False, output.strip())
 

--- a/src/checks/ReachabilityCheck.py
+++ b/src/checks/ReachabilityCheck.py
@@ -34,8 +34,8 @@ class ReachabilityCheck(AbstractCheck):
         try:
             parsed_output = jc.parse("ping", output)
             if int(parsed_output['packets_received']) > 0:
-                reason = "OK" if invert else f"`{device_name}` can reach `{destination}`."
-                return CheckResult(self.description, invert ^ True, "OK")
+                reason = f"`{device_name}` can reach `{destination}`." if invert else "OK"
+                return CheckResult(self.description, invert ^ True, reason)
             else:
                 reason = "OK" if invert else f"`{device_name}` does not receive any answer from `{destination}`."
                 return CheckResult(self.description, invert ^ False, reason)

--- a/src/main.py
+++ b/src/main.py
@@ -203,8 +203,9 @@ def run_on_single_network_scenario(lab_path: str, configuration: dict, lab_templ
     logger.info(f"Total Tests: {total_tests}")
     logger.info(f"Passed Tests: {test_results.count(True)}/{total_tests}")
 
-    logger.info(f"Writing test report for {lab_name} in: {lab_path}...")
-    write_result_to_excel(test_collector.tests[lab_name], lab_path)
+    if not args.skip_report:
+        logger.info(f"Writing test report for {lab_name} in: {lab_path}...")
+        write_result_to_excel(test_collector.tests[lab_name], lab_path)
 
     return test_collector
 
@@ -228,7 +229,7 @@ def run_on_multiple_network_scenarios(labs_path: str, configuration: dict, lab_t
         if test_results:
             test_collector.add_check_results(lab_name, test_results.tests[lab_name])
 
-    if test_collector.tests:
+    if test_collector.tests and not args.skip_report:
         logger.info(f"Writing All Test Results into: {labs_path}")
         write_final_results_to_excel(test_collector, labs_path)
 
@@ -281,6 +282,14 @@ def parse_arguments(argv):
         "--labs",
         required=False,
         help="The path to a directory containing multiple network scenarios to check with the same configuration",
+    )
+
+    parser.add_argument(
+        "--skip-report",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Skip the generation of the report",
     )
 
     return parser.parse_args(argv)


### PR DESCRIPTION
Similar to the daemon check, which can verify that a daemon is not running, I found it useful to be able to check that a device is not reachable. This is for a lab I'm working on that requires students to configure some iptables rules to drop traffic under certain conditions.

This pull request allows for checking that a device cannot reach a certain IP address like:

```
"reachability": {
    "my_device": [
      "!10.10.1.1"
    ]
}
```