### PR TITLE
Allow for checking device not reachable

### DIFF
--- a/src/checks/ReachabilityCheck.py
+++ b/src/checks/ReachabilityCheck.py
@@ -14,10 +14,10 @@ class ReachabilityCheck(AbstractCheck):
 
         if destination.startswith("!"):
             destination = destination[1:]
-            self.description = f"Verifying `{destination}` reachable from device `{device_name}`"
+            self.description = f"Verifying `{destination}` not reachable from device `{device_name}`"
             invert = True
         else:
-            self.description = f"Verifying `{destination}` not reachable from device `{device_name}`"
+            self.description = f"Verifying `{destination}` reachable from device `{device_name}`"
             invert = False
 
         try:
@@ -34,9 +34,10 @@ class ReachabilityCheck(AbstractCheck):
         try:
             parsed_output = jc.parse("ping", output)
             if int(parsed_output['packets_received']) > 0:
+                reason = "OK" if invert else f"`{device_name}` can reach `{destination}`."
                 return CheckResult(self.description, invert ^ True, "OK")
             else:
-                reason = f"`{device_name}` does not receive any answer from `{destination}`."
+                reason = "OK" if invert else f"`{device_name}` does not receive any answer from `{destination}`."
                 return CheckResult(self.description, invert ^ False, reason)
         except Exception:
             return CheckResult(self.description, False, output.strip())

--- a/src/checks/ReachabilityCheck.py
+++ b/src/checks/ReachabilityCheck.py
@@ -10,9 +10,15 @@ from .CheckResult import CheckResult
 class ReachabilityCheck(AbstractCheck):
 
     def check(self, device_name: str, destination: str, lab: Lab) -> CheckResult:
-        self.description = f"Verifying `{destination}` reachability from device `{device_name}`"
-
         kathara_manager: Kathara = Kathara.get_instance()
+
+        if destination.startswith("!"):
+            destination = destination[1:]
+            self.description = f"Verifying `{destination}` reachable from device `{device_name}`"
+            invert = True
+        else:
+            self.description = f"Verifying `{destination}` not reachable from device `{device_name}`"
+            invert = False
 
         try:
             exec_output_gen = kathara_manager.exec(
@@ -21,17 +27,17 @@ class ReachabilityCheck(AbstractCheck):
                 lab_hash=lab.hash,
             )
         except Exception as e:
-            return CheckResult(self.description, False, str(e))
+            return CheckResult(self.description, invert ^ False, str(e))
 
         output = get_output(exec_output_gen).replace("ERROR: ", "")
 
         try:
             parsed_output = jc.parse("ping", output)
             if int(parsed_output['packets_received']) > 0:
-                return CheckResult(self.description, True, "OK")
+                return CheckResult(self.description, invert ^ True, "OK")
             else:
                 reason = f"`{device_name}` does not receive any answer from `{destination}`."
-                return CheckResult(self.description, False, reason)
+                return CheckResult(self.description, invert ^ False, reason)
         except Exception:
             return CheckResult(self.description, False, output.strip())
 

--- a/src/checks/ReachabilityCheck.py
+++ b/src/checks/ReachabilityCheck.py
@@ -34,8 +34,8 @@ class ReachabilityCheck(AbstractCheck):
         try:
             parsed_output = jc.parse("ping", output)
             if int(parsed_output['packets_received']) > 0:
-                reason = "OK" if invert else f"`{device_name}` can reach `{destination}`."
-                return CheckResult(self.description, invert ^ True, "OK")
+                reason = f"`{device_name}` can reach `{destination}`." if invert else "OK"
+                return CheckResult(self.description, invert ^ True, reason)
             else:
                 reason = "OK" if invert else f"`{device_name}` does not receive any answer from `{destination}`."
                 return CheckResult(self.description, invert ^ False, reason)


### PR DESCRIPTION
Similar to the daemon check, which can verify that a daemon is not running, I found it useful to be able to check that a device is not reachable. This is for a lab I'm working on that requires students to configure some iptables rules to drop traffic under certain conditions.

This pull request allows for checking that a device cannot reach a certain IP address like:

```
"reachability": {
    "my_device": [
      "!10.10.1.1"
    ]
}
```